### PR TITLE
hook/table.c: Import assert.h

### DIFF
--- a/hook/table.c
+++ b/hook/table.c
@@ -1,5 +1,6 @@
 #include <windows.h>
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
When building without using the `precompiled.h`, GCC will complain that `hook/table.c` is missing an import of `assert.h` for the `assert` function.